### PR TITLE
fix: update Rust to 1.81 in Dockerfile for lock file v4 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-alpine AS builder
+FROM rust:1.81-alpine AS builder
 
 # Install build dependencies  
 RUN apk add --no-cache \


### PR DESCRIPTION
- Update from rust:1.75-alpine to rust:1.81-alpine
- Fixes Cargo.lock version 4 compatibility issue
- Ensures newer Cargo features are supported