### PR TITLE
fix: configure Leptos environment variables for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ COPY --from=builder --chown=appuser:appuser /app/app/posts ./posts
 COPY --from=builder --chown=appuser:appuser /app/app/public ./public
 
 USER appuser
+
+# Set environment variables
+ENV LEPTOS_OUTPUT_NAME="blog"
+ENV LEPTOS_SITE_ADDR="0.0.0.0:3000"
+ENV LEPTOS_SITE_ROOT="."
+ENV RUST_LOG="info"
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "./app"
+startCommand = "LEPTOS_SITE_ADDR=0.0.0.0:${PORT:-3000} ./app"
 healthcheckPath = "/"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
- Set LEPTOS_OUTPUT_NAME to 'blog' to fix startup error
- Configure LEPTOS_SITE_ADDR to bind to 0.0.0.0:3000
- Use Railway's PORT environment variable in startCommand
- Add RUST_LOG=info for better logging