### PR TITLE
fix: revert to align="center" for GitHub markdown compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="text-align: center;">
+<div align="center">
 
 <pre style="background: transparent;">
 ██████╗ ██╗      ██████╗  ██████╗ 


### PR DESCRIPTION
While align attribute is obsolete in HTML5, GitHub's markdown renderer still relies on it for centering content in README files.

🤖 Generated with [Claude Code](https://claude.ai/code)